### PR TITLE
Decode HTML entities in url

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "files": [
     "src",
     "theme"
-  ]
+  ],
+  "dependencies": {
+    "he": "^1.2.0"
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,7 @@
 const ATTRIBUTE_WHITESPACES = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205f\u3000]/g; // eslint-disable-line no-control-regex
 const SAFE_URL = /^(?:(?:https?|ftps?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i;
 
+import he from 'he'
 
 /**
  * Returns a media attributes based on a given source (url/embed code).
@@ -76,7 +77,7 @@ export function parseMediaEmbed( src ) {
  * @returns {String} Safe URL.
  */
 export function ensureSafeUrl( url ) {
-	url = String( url );
+	url = he.decode( String( url ) );
 	return isSafeUrl( url ) ? url : '#';
 }
 


### PR DESCRIPTION
This converts encoded special characters like `&#39;` present in Google maps links into their original form (i.e. `'`). This way incorrect encoding `&#39;` -> `&amp;#39;` is prevented.